### PR TITLE
Add cmake to requirements on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ pip install -r requirements.txt
 ```
 on macOS please run
 ```bash
+$ brew install cmake
 $ python3 -m nltk.downloader stopwords
 ```
 ## Dataset Folder:


### PR DESCRIPTION
- Install requirements fails when cmake is not installed